### PR TITLE
monitor mode fixed

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,5 +26,4 @@ lib_deps =
 	paulstoffregen/Time@^1.6.1
 	hieromon/AutoConnect@^1.4.2
 	https://github.com/espressif/esp32-camera.git#v2.0.3
-monitor_port = /dev/ttyUSB0
 monitor_speed = 115200


### PR DESCRIPTION
monitor mode does not work when the esp is connected to a different port like com1